### PR TITLE
added Sandbox and Production options

### DIFF
--- a/maya.net/Checkout/CheckoutHandler.cs
+++ b/maya.net/Checkout/CheckoutHandler.cs
@@ -4,15 +4,16 @@ using maya.net.Common;
 using Newtonsoft.Json;
 
 public class CheckoutHandler : ICheckoutHandler{
-    private static readonly string _webhookURL = "https://pg-sandbox.paymaya.com/checkout/v1/checkouts/";
+    private readonly string _webhookURL = "https://pg-sandbox.paymaya.com/checkout/v1/checkouts/";
     private readonly string _publicKey;
     private readonly HttpClient _httpClient;
     // refer to https://stackoverflow.com/questions/53884417/net-core-di-ways-of-passing-parameters-to-constructor
     // when applying dependency injection to this service (and other services here)
-    public CheckoutHandler(string pKey){
+    public CheckoutHandler(string pKey, bool isSandbox = true){
         this._publicKey = pKey;
         this._httpClient = new HttpClient();
         this._httpClient.DefaultRequestHeaders.Clear();
+        if (!isSandbox) _webhookURL = "https://pg.paymaya.com/checkout/v1/checkouts/";
         this._httpClient.BaseAddress = new Uri(_webhookURL);
     }
     public async Task<CheckoutResponse?> CreateCheckout(CheckoutBody checkout){

--- a/maya.net/QR/QRHandler.cs
+++ b/maya.net/QR/QRHandler.cs
@@ -4,15 +4,16 @@ using Newtonsoft.Json;
 namespace maya.net.QR;
 
 public class QRHandler : IQRHandler{
-    private static readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payments/v1/qr/payments/";
+    private readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payments/v1/qr/payments/";
     private readonly string _publicKey;
     private readonly HttpClient _httpClient;
     // refer to https://stackoverflow.com/questions/53884417/net-core-di-ways-of-passing-parameters-to-constructor
     // when applying dependency injection to this service (and other services here)
-    public QRHandler(string pKey){
+    public QRHandler(string pKey, bool isSandbox = true){
         this._publicKey = pKey;
         this._httpClient = new HttpClient();
         this._httpClient.DefaultRequestHeaders.Clear();
+        this._webhookURL = "https://pg.paymaya.com/payments/v1/qr/payments/";
         this._httpClient.BaseAddress = new Uri(_webhookURL);
     }
 

--- a/maya.net/Wallet/WalletHandler.cs
+++ b/maya.net/Wallet/WalletHandler.cs
@@ -5,13 +5,14 @@ using Newtonsoft.Json;
 using maya.net.Common;
 
 public class WalletHandler : IWalletHandler{
-    private static readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payby/v2/paymaya/payments/";
+    private readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payby/v2/paymaya/payments/";
     private readonly string _publicKey;
     private readonly HttpClient _httpClient;
-    public WalletHandler(string pKey, string sKey){
+    public WalletHandler(string pKey, bool isSandbox = true){
         this._publicKey = pKey;
         this._httpClient = new HttpClient();
         this._httpClient.DefaultRequestHeaders.Clear();
+        if (!isSandbox) _webhookURL = "https://pg.paymaya.com/payby/v2/paymaya/payments/";
         this._httpClient.BaseAddress = new Uri(_webhookURL);
     }
     public async Task<WalletResponse?> CreateSinglePayment(WalletBody wallet){
@@ -32,6 +33,7 @@ public class WalletHandler : IWalletHandler{
             LogHelper.logError(response, responseBody);
             return null;
         }
+        
         return JsonConvert.DeserializeObject<WalletResponse>(responseBody);
     }
 }

--- a/maya.net/Webhooks/WebhookHandler.cs
+++ b/maya.net/Webhooks/WebhookHandler.cs
@@ -1,24 +1,18 @@
 namespace maya.net.Webhooks;
 
-using maya.net;
 using maya.net.Common;
 using System.Net.Http;
-using System.Net.Http.Json;
-using System.Runtime.InteropServices;
 using Newtonsoft.Json;
 
 public class WebhookHandler : IWebhookHandler{
-    private static readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payments/v1/webhooks/";
-    private readonly string _publicKey;
+    private readonly string _webhookURL = "https://pg-sandbox.paymaya.com/payments/v1/webhooks/";
     private readonly string _secretKey;
     private readonly HttpClient _httpClient;
-    private readonly UriBuilder _uriBuilder;
-    public WebhookHandler(string pKey, string sKey){
-        this._publicKey = pKey;
+    public WebhookHandler(string sKey, bool isSandbox = true){
         this._secretKey = sKey;
         this._httpClient = new HttpClient();
-        this._uriBuilder = new UriBuilder(_webhookURL);
         this._httpClient.DefaultRequestHeaders.Clear();
+        if (!isSandbox) this._webhookURL = "https://pg.paymaya.com/payments/v1/webhooks/";
         this._httpClient.BaseAddress = new Uri(_webhookURL);
     }
     public async Task<Webhook?> CreateWebhook(string name, string callback){


### PR DESCRIPTION
Refactored all handlers to have the option in either using Production API or Sandbox API thru a constructor boolean value. By default, all handlers are set to use the Sandbox API and can be overridden by setting `isSandbox` in a handler's constructor to false.
![image](https://github.com/Towphe/maya.net/assets/74641207/4f39c09f-da39-45a7-aef7-68106b6b72db)


